### PR TITLE
Bump addressable to 2.9.0 to fix ReDoS vulnerability (CVE-2026-35611)

### DIFF
--- a/slack-unfurling-redmine/Gemfile.lock
+++ b/slack-unfurling-redmine/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     bigdecimal (4.0.1)
     crack (1.0.1)


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
